### PR TITLE
RELOAD LOCAL - Prevent collision of .env variables with the same starting name.

### DIFF
--- a/bin/reload-local.sh
+++ b/bin/reload-local.sh
@@ -91,10 +91,10 @@ EOF
 #######################################
 function create_database() {
   # Get connection credentials from .env file.
-  MYSQL_ROOT_PASS=$(egrep DB_ROOT_PASSWORD ${PROJECT_ROOT}/.env | sed s/DB_ROOT_PASSWORD=//)
-  MYSQL_HOST=$(egrep DB_HOST ${PROJECT_ROOT}/.env | sed s/DB_HOST=//)
-  MYSQL_DB_NAME=$(egrep DB_NAME ${PROJECT_ROOT}/.env | sed s/DB_NAME=//)
-  MYSQL_DB_USER=$(egrep DB_USER ${PROJECT_ROOT}/.env | sed s/DB_USER=//)
+  MYSQL_ROOT_PASS=$(egrep DB_ROOT_PASSWORD[^a-zA-Z_] ${PROJECT_ROOT}/.env | sed s/DB_ROOT_PASSWORD=//)
+  MYSQL_HOST=$(egrep DB_HOST[^a-zA-Z_] ${PROJECT_ROOT}/.env | sed s/DB_HOST=//)
+  MYSQL_DB_NAME=$(egrep DB_NAME[^a-zA-Z_] ${PROJECT_ROOT}/.env | sed s/DB_NAME=//)
+  MYSQL_DB_USER=$(egrep DB_USER[^a-zA-Z_] ${PROJECT_ROOT}/.env | sed s/DB_USER=//)
 
   if [ $SITE != $DEFAULT_SITE ]
   then


### PR DESCRIPTION
The reload local script failed to me when I had set up a variable with the name DB_HOST_LEGACY. The problem is that the egrep sentence detects this variable instead of DB_HOST. This PR solves the problems. Please review, thanks!