### PR TITLE
Remove composer dependency package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     ],
     "require": {
         "composer-plugin-api": "^1.1",
-        "composer": "^1.8@stable",
         "drush/drush": "^9.0|^10.0",
         "php": ">=7.0.8"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "composer-plugin-api": "^1.1",
-        "composer/composer": "^1.8@stable",
+        "composer": "^1.8@stable",
         "drush/drush": "^9.0|^10.0",
         "php": ">=7.0.8"
     },


### PR DESCRIPTION
Remove composer dependency package because in this proyect is using the global composer, and drupal 9 needs composer 2 as dependency. Is not the same "composer/composer" as a package than composer as global.