### PR TITLE
Silence scripts exist on composer actions

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -64,8 +64,6 @@ class Handler {
    *   Error when not created
    */
   public function createSymlinks() {
-    $this->io->write('Scripthor start.');
-
     if ($this->createScriptDir()) {
       $this->createScriptLink();
     }
@@ -73,7 +71,6 @@ class Handler {
       $this->io->writeError('./scripts directory not created.');
       throw new \Exception('./scripts directory not created.');
     }
-    $this->io->write('Scripthor finished.');
   }
 
   /**
@@ -104,9 +101,6 @@ class Handler {
       if (!file_exists($script)) {
         symlink(self::TARGET_DIR . $file, $script);
         $this->io->write('Script created: ' . $file);
-      }
-      else {
-        $this->io->write('Script exists: ' . $file);
       }
     }
   }

--- a/src/MetadropPlugin.php
+++ b/src/MetadropPlugin.php
@@ -75,7 +75,6 @@ class MetadropPlugin implements PluginInterface, EventSubscriberInterface, Capab
    * @throws \Exception
    */
   public function scripthorInstaller(Event $event) {
-    $this->io->write('scripthorInstaller: ' . $event->getName());
     $this->handler->createSymlinks();
   }
 
@@ -86,7 +85,6 @@ class MetadropPlugin implements PluginInterface, EventSubscriberInterface, Capab
    *   The composer event.
    */
   public function onCreateProject(Event $event) {
-    $this->io->write('scripthorInstaller: ' . $event->getName());
     $this->handler->createProjectAssistant();
   }
 


### PR DESCRIPTION
Scripthor is notifying so much log information when (I think) it is not needed and only increases composer log messages which is a problem on Ci/CD platforms.
I have kept other messages like link creation.

Example

```
...
Writing lock file
Generating autoload files
composer/package-versions-deprecated: Generating version class...
composer/package-versions-deprecated: ...done generating version class
90 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
scripthorInstaller: post-update-cmd
Scripthor start.
Script exists: frontend-build.sh
Script exists: copy-content-config-entity-to-module.sh
Script exists: reload-local.sh
Script exists: setup-traefik-port.sh
Script exists: backup.sh
Script exists: update-helper.sh
Scripthor finished.
```