### PR TITLE
Use the composer from docker php service to avoid incompatibilities with real machine global composer version.

### DIFF
--- a/bin/reload-local.sh
+++ b/bin/reload-local.sh
@@ -47,7 +47,7 @@ SITE=$DEFAULT_SITE
 DOCKER_EXEC_PHP="docker-compose exec php"
 DOCKER_EXEC_TTY_PHP="docker-compose exec -T php"
 DOCKER_EXEC_NPM="docker-compose exec node"
-COMPOSER_EXEC="composer"
+COMPOSER_EXEC="docker-compose exec php composer"
 RM_EXEC="rm"
 
 # Having a month based db backup filename ensures the database is refreshed at least every month.

--- a/bin/reload-local.sh
+++ b/bin/reload-local.sh
@@ -230,8 +230,8 @@ cd ${PROJECT_ROOT}
 
 if [[ ${DATABASE_ONLY} = false ]]
 then
-  # Install dependencies and compile css.
-  $COMPOSER_EXEC install --ignore-platform-reqs
+  # Install dependencies.
+  $COMPOSER_EXEC install
 
 fi
 


### PR DESCRIPTION
Use docker service composer, to avoid incompatibilities with linux global versions.

Docker PHP service must have the composer right version, matching with the server requirements, and the "real machine" composer must not be used to install dependencies.