### PR TITLE
Updates with update-helper.sh script without require-dev packages

### DIFF
--- a/bin/update-helper.sh
+++ b/bin/update-helper.sh
@@ -13,9 +13,12 @@ Update includes:
   - For each package try to update and commit it (recovers previous state if fails)
 
 Usage: ${0##*/} [--author=Name <user@example.com>]
-  -h|--help         Show this help and exit.
 
-  --author   Overrides default Git author name. Example Name <user@example.com>
+  -h|--help                 Show this help and exit.
+
+  --author                  Overrides default Git author name. Example Name <user@example.com>
+
+  --no-dev                  Disables search in require-dev packages.
 
 EOF
 }

--- a/bin/update-helper.sh
+++ b/bin/update-helper.sh
@@ -88,6 +88,10 @@ do
         echo "GIT author will be overriden with: $author"
         author_commit="--author=\"$author\""
         ;;
+    --no-dev)
+        echo "Updates without require-dev packages."
+        updates="composer show -omND --no-dev"
+        ;;
     -?*|*)
         printf 'ERROR: Unknown option: %s\n' "$1" >&2
         show_help

--- a/bin/update-helper.sh
+++ b/bin/update-helper.sh
@@ -27,7 +27,7 @@ function composer_update_outdated() {
   DRUPAL_VERSION=$1
 
   # Outdated, minor version, just name, direct dependencies:
-  for c in $(composer show -omND)
+  for c in $($updates)
     do
       echo -e "\n/// UPDATING: " $c "///////////////////////////////"
 
@@ -72,6 +72,7 @@ function composer_update_outdated() {
 ## Defaults:
 author_commit=""
 drush="vendor/bin/drush"
+updates="composer show -omND"
 
 # Process script options.
 #########################
@@ -97,7 +98,7 @@ shift
 done
 
 # Get the packages to be updated (direct dependencies): outdated, minor version only
-packages_to_update=$(composer show -omND)
+packages_to_update=$($updates)
 DRUPAL_VERSION="$(${drush} status --format=list 'Drupal version' | cut -d. -f1 -)"
 
 echo -e "\nPackages to update:"

--- a/bin/update-helper.sh
+++ b/bin/update-helper.sh
@@ -90,7 +90,7 @@ do
         ;;
     --no-dev)
         echo "Updates without require-dev packages."
-        updates="composer show -omND --no-dev"
+        updates+=" --no-dev"
         ;;
     -?*|*)
         printf 'ERROR: Unknown option: %s\n' "$1" >&2


### PR DESCRIPTION
In some cases, if we are currently only maintaining and not developing a project, we are not interested in updating the development packages, as these may cause dependency conflicts that would delay the maintenance of the project.

A "--no-dev" option is added which updates all packages except those in "require-dev".