### PR TITLE
Updated drush supported version to v11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "composer-plugin-api": "^1.1 || ^2.0",
         "composer/composer": "^1.10.23@stable || ^2.1.9",
-        "drush/drush": "^9.0|^10.0",
+        "drush/drush": "^9.0|^10.0|^11.0",
 	"consolidation/robo":"^3 || ^4",
         "php": ">=7.0.8"
     },


### PR DESCRIPTION
With the release of drush 11 6 months ago, the need has arisen in some projects to use this new version. I have updated the composer.json file with the new version, keeping the olds 9 and 10 too.