### PR TITLE
Remove sync label due is an optional parameter and not compatible with drush 11

### DIFF
--- a/bin/reload-local.sh
+++ b/bin/reload-local.sh
@@ -281,7 +281,7 @@ then
     $DOCKER_EXEC_PHP drush @${LOCAL_ALIAS} locale-update
   fi
 
-  $DOCKER_EXEC_PHP drush @${LOCAL_ALIAS} cim sync -y
+  $DOCKER_EXEC_PHP drush @${LOCAL_ALIAS} cim -y
 
   $DOCKER_EXEC_PHP drush @${LOCAL_ALIAS} deploy:hook -y
 


### PR DESCRIPTION
 On drush 11 the optional parameter label is removed, because we only use the sync directory (metadrop boilerplate), this label is not necessary for the previous versions.

drush 10.6.2:
```
Import config from a config directory.

Arguments:
 [label] A config directory label (i.e. a key in \$config_directories array in settings.php). 

Options:
 --preview[=PREVIEW] Deprecated. Format for displaying proposed changes. Recognized values: list, diff. [default: list]                                                                                                  
 --source=SOURCE     An arbitrary directory that holds the configuration files. An alternative to label argument                                                                                                         
 --partial           Allows for partial config imports from the source directory. Only updates and new configs will be processed with this flag (missing configs will not be deleted). No config transformation happens. 
 --diff              Show preview as a diff.                                                                                                                                                                             

Topics:
 drush topic docs:deploy Deploy command for Drupal.
```

drush 11.1.1:
```
wodby@php.container:/var/www/html $ drush cim --help
Import config from a config directory.

Options:
 --source=SOURCE An arbitrary directory that holds the configuration files.                                                                                                                                          
 --partial       Allows for partial config imports from the source directory. Only updates and new configs will be processed with this flag (missing configs will not be deleted). No config transformation happens. 
 --diff          Show preview as a diff. 
```
